### PR TITLE
Initial gradle sync fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'


### PR DESCRIPTION
When the project is cloned, initial gradle sync fails with

> Could not find aapt2-proto.jar (com.android.tools.build:aapt2-proto:0.3.1).
> Searched in the following locations:
>    https://jcenter.bintray.com/com/android/tools/build/aapt2-proto/0.3.1/aapt2-proto-0.3.1.jar

As can be found, `google()` maven repository needs to be the first one in build.gradle.

